### PR TITLE
Basic `VelloLine` shape and new `vello_basic` example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2358,6 +2358,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_vello_renderer",
+ "motiongfx_bevy",
  "motiongfx_core",
 ]
 

--- a/crates/motiongfx_bevy/src/lib.rs
+++ b/crates/motiongfx_bevy/src/lib.rs
@@ -6,8 +6,8 @@ use bevy_render::prelude::*;
 use bevy_transform::prelude::*;
 use motiongfx_core::prelude::*;
 
-pub mod standard_material;
-pub mod transform;
+mod standard_material;
+mod transform;
 
 pub mod prelude {
     pub use crate::{

--- a/crates/motiongfx_core/src/lerp.rs
+++ b/crates/motiongfx_core/src/lerp.rs
@@ -42,6 +42,7 @@ impl Lerp<f32> for kurbo::Circle {
 impl Lerp<f32> for kurbo::Line {
     fn lerp(&self, other: &Self, t: f32) -> Self {
         let t: f64 = t as f64;
+
         kurbo::Line {
             p0: kurbo::Point::lerp(self.p0, other.p1, t),
             p1: kurbo::Point::lerp(self.p1, other.p1, t),

--- a/crates/motiongfx_core/src/lerp.rs
+++ b/crates/motiongfx_core/src/lerp.rs
@@ -10,7 +10,7 @@ pub trait Lerp<Time> {
 
 impl Lerp<f32> for kurbo::RoundedRectRadii {
     fn lerp(&self, other: &Self, t: f32) -> Self {
-        kurbo::RoundedRectRadii {
+        Self {
             top_left: f64::lerp(&self.top_left, &other.top_left, t),
             top_right: f64::lerp(&self.top_right, &other.top_right, t),
             bottom_right: f64::lerp(&self.bottom_right, &other.bottom_right, t),
@@ -21,7 +21,7 @@ impl Lerp<f32> for kurbo::RoundedRectRadii {
 
 impl Lerp<f32> for kurbo::Rect {
     fn lerp(&self, other: &Self, t: f32) -> Self {
-        kurbo::Rect {
+        Self {
             x0: f64::lerp(&self.x0, &other.x0, t),
             y0: f64::lerp(&self.y0, &other.y0, t),
             x1: f64::lerp(&self.x1, &other.x1, t),
@@ -32,7 +32,7 @@ impl Lerp<f32> for kurbo::Rect {
 
 impl Lerp<f32> for kurbo::Circle {
     fn lerp(&self, other: &Self, t: f32) -> Self {
-        kurbo::Circle {
+        Self {
             center: kurbo::Point::lerp(self.center, other.center, t as f64),
             radius: f64::lerp(&self.radius, &other.radius, t),
         }
@@ -43,7 +43,7 @@ impl Lerp<f32> for kurbo::Line {
     fn lerp(&self, other: &Self, t: f32) -> Self {
         let t: f64 = t as f64;
 
-        kurbo::Line {
+        Self {
             p0: kurbo::Point::lerp(self.p0, other.p1, t),
             p1: kurbo::Point::lerp(self.p1, other.p1, t),
         }
@@ -65,19 +65,19 @@ impl Lerp<f32> for kurbo::Stroke {
 impl Lerp<f32> for peniko::Brush {
     fn lerp(&self, other: &Self, t: f32) -> Self {
         match self {
-            peniko::Brush::Solid(self_color) => match other {
+            Self::Solid(self_color) => match other {
                 // =====================
                 // Solid -> Solid
                 // =====================
-                peniko::Brush::Solid(other_color) => {
-                    return peniko::Brush::Solid(peniko::Color::lerp(self_color, other_color, t));
+                Self::Solid(other_color) => {
+                    return Self::Solid(peniko::Color::lerp(self_color, other_color, t));
                 }
 
                 // =====================
                 // Solid -> Gradient
                 // =====================
-                peniko::Brush::Gradient(other_grad) => {
-                    return peniko::Brush::Gradient(peniko::Gradient {
+                Self::Gradient(other_grad) => {
+                    return Self::Gradient(peniko::Gradient {
                         kind: other_grad.kind,
                         extend: other_grad.extend,
                         stops: peniko::Color::cross_lerp(self_color, &other_grad.stops, t),
@@ -85,15 +85,15 @@ impl Lerp<f32> for peniko::Brush {
                 }
 
                 // Image interpolation is not supported
-                peniko::Brush::Image(_) => {}
+                Self::Image(_) => {}
             },
 
-            peniko::Brush::Gradient(self_grad) => match other {
+            Self::Gradient(self_grad) => match other {
                 // =====================
                 // Gradient -> Solid
                 // =====================
-                peniko::Brush::Solid(other_color) => {
-                    return peniko::Brush::Gradient(peniko::Gradient {
+                Self::Solid(other_color) => {
+                    return Self::Gradient(peniko::Gradient {
                         kind: self_grad.kind,
                         extend: self_grad.extend,
                         stops: peniko::ColorStops::cross_lerp(&self_grad.stops, other_color, t),
@@ -103,13 +103,13 @@ impl Lerp<f32> for peniko::Brush {
                 // =====================
                 // Gradient -> Gradient
                 // =====================
-                peniko::Brush::Gradient(other_grad) => 'grad: {
+                Self::Gradient(other_grad) => 'grad: {
                     // Gradient kind and extend must be the same, otherwise, fallback
                     if self_grad.kind != other_grad.kind && self_grad.extend != other_grad.extend {
                         break 'grad;
                     }
 
-                    return peniko::Brush::Gradient(peniko::Gradient {
+                    return Self::Gradient(peniko::Gradient {
                         kind: self_grad.kind,
                         extend: self_grad.extend,
                         stops: peniko::ColorStops::lerp(&self_grad.stops, &other_grad.stops, t),
@@ -117,11 +117,11 @@ impl Lerp<f32> for peniko::Brush {
                 }
 
                 // Image interpolation is not supported
-                peniko::Brush::Image(_) => {}
+                Self::Image(_) => {}
             },
 
             // Image interpolation is not supported
-            peniko::Brush::Image(_) => {}
+            Self::Image(_) => {}
         }
 
         // Fallback to discrete interpolation

--- a/crates/motiongfx_core/src/lerp.rs
+++ b/crates/motiongfx_core/src/lerp.rs
@@ -39,6 +39,16 @@ impl Lerp<f32> for kurbo::Circle {
     }
 }
 
+impl Lerp<f32> for kurbo::Line {
+    fn lerp(&self, other: &Self, t: f32) -> Self {
+        let t: f64 = t as f64;
+        kurbo::Line {
+            p0: kurbo::Point::lerp(self.p0, other.p1, t),
+            p1: kurbo::Point::lerp(self.p1, other.p1, t),
+        }
+    }
+}
+
 impl Lerp<f32> for kurbo::Stroke {
     fn lerp(&self, other: &Self, t: f32) -> Self {
         Self {

--- a/crates/motiongfx_core/src/lerp.rs
+++ b/crates/motiongfx_core/src/lerp.rs
@@ -44,7 +44,7 @@ impl Lerp<f32> for kurbo::Line {
         let t: f64 = t as f64;
 
         Self {
-            p0: kurbo::Point::lerp(self.p0, other.p1, t),
+            p0: kurbo::Point::lerp(self.p0, other.p0, t),
             p1: kurbo::Point::lerp(self.p1, other.p1, t),
         }
     }

--- a/crates/motiongfx_vello/Cargo.toml
+++ b/crates/motiongfx_vello/Cargo.toml
@@ -15,4 +15,5 @@ bevy_render = { version = "0.12", default-features = false }
 bevy_transform = { version = "0.12", default-features = false }
 bevy_utils = { version = "0.12", default-features = false }
 motiongfx_core = { version = "0.1.0", path = "../motiongfx_core" }
+motiongfx_bevy = { version = "0.1.0", path = "../motiongfx_bevy" }
 bevy_vello_renderer = { git = "https://github.com/nixon-voxell/bevy_vello_renderer", rev = "b9fb17a188c302047d7718fb606ba2b0b0ada8c7" }

--- a/crates/motiongfx_vello/src/fill_style.rs
+++ b/crates/motiongfx_vello/src/fill_style.rs
@@ -35,12 +35,12 @@ impl FillStyle {
 
 impl VelloBuilder for FillStyle {
     #[inline]
-    fn should_build(&self) -> bool {
+    fn is_built(&self) -> bool {
         self.should_build
     }
 
     #[inline]
-    fn set_should_build(&mut self, should_build: bool) {
+    fn set_built(&mut self, should_build: bool) {
         self.should_build = should_build
     }
 }
@@ -105,6 +105,6 @@ impl FillStyleMotion {
         _: &mut ResMut<EmptyRes>,
     ) {
         fill.brush = peniko::Brush::lerp(begin, end, t);
-        fill.set_should_build(true);
+        fill.set_built(false);
     }
 }

--- a/crates/motiongfx_vello/src/lib.rs
+++ b/crates/motiongfx_vello/src/lib.rs
@@ -7,18 +7,40 @@ use bevy_vello_renderer::{
 };
 use motiongfx_core::prelude::*;
 
-pub mod convert;
-pub mod fill_style;
-pub mod stroke_style;
-pub mod vello_motion;
-pub mod vello_vector;
+mod convert;
+mod fill_style;
+mod stroke_style;
+mod vello_motion;
+mod vello_vector;
+
+pub mod prelude {
+    pub use crate::{
+        convert::*,
+        fill_style::{FillStyle, FillStyleMotion},
+        stroke_style::{StrokeStyle, StrokeStyleMotion},
+        vello_motion::{
+            circle_motion::{VelloCircleBundleMotion, VelloCircleMotion},
+            rect_motion::{VelloRectBundleMotion, VelloRectMotion},
+        },
+        vello_vector::{
+            circle::{VelloCircle, VelloCircleBundle},
+            line::{VelloLine, VelloLineBundle},
+            rect::{VelloRect, VelloRectBundle},
+        },
+    };
+    pub use bevy_vello_renderer::prelude::*;
+}
 
 pub struct MotionGfxVello;
 
 impl Plugin for MotionGfxVello {
     fn build(&self, app: &mut App) {
         app.add_plugins(VelloRenderPlugin)
-            .add_plugins((vello_motion::rect_motion::VelloRectMotionPlugin,))
+            .add_plugins((
+                vello_motion::circle_motion::VelloCircleMotionPlugin,
+                vello_motion::rect_motion::VelloRectMotionPlugin,
+                // vello_motion::line_motion::VelloLineMotionPlugin,
+            ))
             .add_systems(
                 PostUpdate,
                 (

--- a/crates/motiongfx_vello/src/lib.rs
+++ b/crates/motiongfx_vello/src/lib.rs
@@ -10,7 +10,7 @@ use motiongfx_core::prelude::*;
 pub mod convert;
 pub mod fill_style;
 pub mod stroke_style;
-// pub mod vector_style;
+pub mod vello_motion;
 pub mod vello_vector;
 
 pub struct MotionGfxVello;
@@ -18,7 +18,7 @@ pub struct MotionGfxVello;
 impl Plugin for MotionGfxVello {
     fn build(&self, app: &mut App) {
         app.add_plugins(VelloRenderPlugin)
-            // .add_systems(PostStartup)
+            .add_plugins((vello_motion::rect_motion::VelloRectMotionPlugin,))
             .add_systems(
                 PostUpdate,
                 (
@@ -26,15 +26,9 @@ impl Plugin for MotionGfxVello {
                     vello_vector::vector_builder::<vello_vector::rect::VelloRect>,
                     vello_vector::vector_builder::<vello_vector::circle::VelloCircle>,
                     // Sequences
-                    sequence_player_system::<vello_vector::rect::VelloRect, kurbo::Rect, EmptyRes>,
                     sequence_player_system::<fill_style::FillStyle, peniko::Brush, EmptyRes>,
                     sequence_player_system::<stroke_style::StrokeStyle, peniko::Brush, EmptyRes>,
                     sequence_player_system::<stroke_style::StrokeStyle, kurbo::Stroke, EmptyRes>,
-                    sequence_player_system::<
-                        vello_vector::rect::VelloRect,
-                        kurbo::RoundedRectRadii,
-                        EmptyRes,
-                    >,
                 ),
             );
     }

--- a/crates/motiongfx_vello/src/lib.rs
+++ b/crates/motiongfx_vello/src/lib.rs
@@ -20,6 +20,7 @@ pub mod prelude {
         stroke_style::{StrokeStyle, StrokeStyleMotion},
         vello_motion::{
             circle_motion::{VelloCircleBundleMotion, VelloCircleMotion},
+            line_motion::{VelloLineBundleMotion, VelloLineMotion},
             rect_motion::{VelloRectBundleMotion, VelloRectMotion},
         },
         vello_vector::{
@@ -39,7 +40,7 @@ impl Plugin for MotionGfxVello {
             .add_plugins((
                 vello_motion::circle_motion::VelloCircleMotionPlugin,
                 vello_motion::rect_motion::VelloRectMotionPlugin,
-                // vello_motion::line_motion::VelloLineMotionPlugin,
+                vello_motion::line_motion::VelloLineMotionPlugin,
             ))
             .add_systems(
                 PostUpdate,
@@ -47,6 +48,7 @@ impl Plugin for MotionGfxVello {
                     // Vector builders
                     vello_vector::vector_builder::<vello_vector::rect::VelloRect>,
                     vello_vector::vector_builder::<vello_vector::circle::VelloCircle>,
+                    vello_vector::vector_builder::<vello_vector::line::VelloLine>,
                     // Sequences
                     sequence_player_system::<fill_style::FillStyle, peniko::Brush, EmptyRes>,
                     sequence_player_system::<stroke_style::StrokeStyle, peniko::Brush, EmptyRes>,

--- a/crates/motiongfx_vello/src/stroke_style.rs
+++ b/crates/motiongfx_vello/src/stroke_style.rs
@@ -19,8 +19,8 @@ impl StrokeStyle {
     }
 
     #[inline]
-    pub fn with_style(mut self, style: kurbo::Stroke) -> Self {
-        self.style = style;
+    pub fn with_style(mut self, style: impl Into<KurboStroke>) -> Self {
+        self.style = style.into().0;
         self
     }
 
@@ -33,12 +33,12 @@ impl StrokeStyle {
 
 impl VelloBuilder for StrokeStyle {
     #[inline]
-    fn should_build(&self) -> bool {
+    fn is_built(&self) -> bool {
         self.should_build
     }
 
     #[inline]
-    fn set_should_build(&mut self, should_build: bool) {
+    fn set_built(&mut self, should_build: bool) {
         self.should_build = should_build
     }
 }
@@ -91,7 +91,7 @@ impl StrokeStyleMotion {
         _: &mut ResMut<EmptyRes>,
     ) {
         stroke.brush = peniko::Brush::lerp(begin, end, t);
-        stroke.set_should_build(true);
+        stroke.set_built(true);
     }
 
     // =====================
@@ -123,6 +123,6 @@ impl StrokeStyleMotion {
         _: &mut ResMut<EmptyRes>,
     ) {
         stroke.style = kurbo::Stroke::lerp(begin, end, t);
-        stroke.set_should_build(true);
+        stroke.set_built(true);
     }
 }

--- a/crates/motiongfx_vello/src/vello_motion/circle_motion.rs
+++ b/crates/motiongfx_vello/src/vello_motion/circle_motion.rs
@@ -1,0 +1,118 @@
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_vello_renderer::vello::kurbo;
+use motiongfx_core::prelude::*;
+
+use crate::{
+    fill_style::FillStyleMotion,
+    stroke_style::StrokeStyleMotion,
+    vello_vector::{
+        circle::{VelloCircle, VelloCircleBundle},
+        VelloBuilder,
+    },
+};
+
+pub(crate) struct VelloCircleMotionPlugin;
+
+impl Plugin for VelloCircleMotionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (
+                sequence_player_system::<VelloCircle, kurbo::Circle, EmptyRes>,
+                sequence_player_system::<VelloCircle, f64, EmptyRes>,
+            ),
+        );
+    }
+}
+
+pub struct VelloCircleBundleMotion {
+    pub circle: VelloCircleMotion,
+    pub fill: FillStyleMotion,
+    pub stroke: StrokeStyleMotion,
+}
+
+impl VelloCircleBundleMotion {
+    pub fn new(target_id: Entity, bundle: VelloCircleBundle) -> Self {
+        Self {
+            circle: VelloCircleMotion::new(target_id, bundle.circle),
+            fill: FillStyleMotion::new(target_id, bundle.fill),
+            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+        }
+    }
+}
+
+pub struct VelloCircleMotion {
+    target_id: Entity,
+    vello_circle: VelloCircle,
+}
+
+impl VelloCircleMotion {
+    pub fn new(target_id: Entity, vello_circle: VelloCircle) -> Self {
+        Self {
+            target_id,
+            vello_circle,
+        }
+    }
+
+    // =====================
+    // Circle
+    // =====================
+    pub fn circle_to(
+        &mut self,
+        new_circle: impl Into<kurbo::Circle>,
+    ) -> Action<VelloCircle, kurbo::Circle, EmptyRes> {
+        let new_circle: kurbo::Circle = new_circle.into();
+
+        let action: Action<VelloCircle, kurbo::Circle, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_circle.circle,
+            new_circle,
+            Self::circle_interp,
+        );
+
+        self.vello_circle.circle = new_circle;
+
+        action
+    }
+
+    fn circle_interp(
+        vello_circle: &mut VelloCircle,
+        begin: &kurbo::Circle,
+        end: &kurbo::Circle,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_circle.circle = kurbo::Circle::lerp(begin, end, t);
+        vello_circle.set_built(false);
+    }
+
+    // =====================
+    // Circle.radius
+    // =====================
+    pub fn inflate(&mut self, inflation: f64) -> Action<VelloCircle, f64, EmptyRes> {
+        let new_radius: f64 = self.vello_circle.circle.radius + inflation;
+
+        let action: Action<VelloCircle, f64, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_circle.circle.radius,
+            new_radius,
+            Self::circle_radius_interp,
+        );
+
+        self.vello_circle.circle.radius = new_radius;
+
+        action
+    }
+
+    fn circle_radius_interp(
+        vello_circle: &mut VelloCircle,
+        begin: &f64,
+        end: &f64,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_circle.circle.radius = f64::lerp(begin, end, t);
+        vello_circle.set_built(false);
+    }
+}

--- a/crates/motiongfx_vello/src/vello_motion/circle_motion.rs
+++ b/crates/motiongfx_vello/src/vello_motion/circle_motion.rs
@@ -1,6 +1,7 @@
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_vello_renderer::vello::kurbo;
+use motiongfx_bevy::prelude::TransformMotion;
 use motiongfx_core::prelude::*;
 
 use crate::{
@@ -30,6 +31,7 @@ pub struct VelloCircleBundleMotion {
     pub circle: VelloCircleMotion,
     pub fill: FillStyleMotion,
     pub stroke: StrokeStyleMotion,
+    pub transform: TransformMotion,
 }
 
 impl VelloCircleBundleMotion {
@@ -38,6 +40,7 @@ impl VelloCircleBundleMotion {
             circle: VelloCircleMotion::new(target_id, bundle.circle),
             fill: FillStyleMotion::new(target_id, bundle.fill),
             stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+            transform: TransformMotion::new(target_id, bundle.fragment_bundle.transform.local),
         }
     }
 }

--- a/crates/motiongfx_vello/src/vello_motion/line_motion.rs
+++ b/crates/motiongfx_vello/src/vello_motion/line_motion.rs
@@ -1,0 +1,139 @@
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_math::DVec2;
+use bevy_vello_renderer::vello::kurbo;
+use motiongfx_bevy::prelude::TransformMotion;
+use motiongfx_core::prelude::*;
+
+use crate::{
+    prelude::StrokeStyleMotion,
+    vello_vector::{
+        line::{VelloLine, VelloLineBundle},
+        VelloBuilder,
+    },
+};
+
+pub(crate) struct VelloLineMotionPlugin;
+
+impl Plugin for VelloLineMotionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (
+                sequence_player_system::<VelloLine, kurbo::Line, EmptyRes>,
+                sequence_player_system::<VelloLine, f64, EmptyRes>,
+            ),
+        );
+    }
+}
+
+pub struct VelloLineBundleMotion {
+    pub line: VelloLineMotion,
+    pub stroke: StrokeStyleMotion,
+    pub transform: TransformMotion,
+}
+
+impl VelloLineBundleMotion {
+    pub fn new(target_id: Entity, bundle: VelloLineBundle) -> Self {
+        Self {
+            line: VelloLineMotion::new(target_id, bundle.line),
+            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+            transform: TransformMotion::new(target_id, bundle.fragment_bundle.transform.local),
+        }
+    }
+}
+
+pub struct VelloLineMotion {
+    target_id: Entity,
+    vello_line: VelloLine,
+}
+
+impl VelloLineMotion {
+    pub fn new(target_id: Entity, vello_line: VelloLine) -> Self {
+        Self {
+            target_id,
+            vello_line,
+        }
+    }
+
+    pub fn line_to(
+        &mut self,
+        new_line: impl Into<kurbo::Line>,
+    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        let new_line: kurbo::Line = new_line.into();
+
+        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_line.line,
+            new_line,
+            Self::line_interp,
+        );
+
+        self.vello_line.line = new_line;
+
+        action
+    }
+
+    /// Extend the line based on given `DVec2` percentage where `x` represents `p0` and `y` represents `p1`.
+    pub fn percentage_extend(
+        &mut self,
+        extension: f64,
+        percentage: impl Into<DVec2>,
+    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        let percentage: DVec2 = percentage.into();
+
+        let mut new_line: kurbo::Line = self.vello_line.line;
+        let direction: kurbo::Vec2 = self.get_p0_direction();
+
+        new_line.p0 += direction * extension * percentage.x;
+        new_line.p1 -= direction * extension * percentage.y;
+
+        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_line.line,
+            new_line,
+            Self::line_interp,
+        );
+
+        self.vello_line.line = new_line;
+
+        action
+    }
+
+    /// Extend the line only using `p0`.
+    pub fn extend_p0(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(1.0, 0.0))
+    }
+
+    /// Extend the line only using `p1`.
+    pub fn extend_p1(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(0.0, 1.0))
+    }
+
+    /// Extend the line on both `p0` and `p1`.
+    pub fn extend(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(1.0, 1.0))
+    }
+
+    fn get_p0_direction(&self) -> kurbo::Vec2 {
+        let mut direction: kurbo::Vec2 = self.vello_line.line.p0 - self.vello_line.line.p1;
+
+        // If direction has no magnitude, a horizontal direction will be assigned
+        if direction.length_squared() == 0.0 {
+            direction.x = -1.0
+        }
+
+        (direction).normalize()
+    }
+
+    fn line_interp(
+        vello_line: &mut VelloLine,
+        begin: &kurbo::Line,
+        end: &kurbo::Line,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_line.line = kurbo::Line::lerp(begin, end, t);
+        vello_line.set_built(false);
+    }
+}

--- a/crates/motiongfx_vello/src/vello_motion/mod.rs
+++ b/crates/motiongfx_vello/src/vello_motion/mod.rs
@@ -1,0 +1,2 @@
+pub mod circle_motion;
+pub mod rect_motion;

--- a/crates/motiongfx_vello/src/vello_motion/mod.rs
+++ b/crates/motiongfx_vello/src/vello_motion/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod circle_motion;
+pub(crate) mod line_motion;
 pub(crate) mod rect_motion;

--- a/crates/motiongfx_vello/src/vello_motion/mod.rs
+++ b/crates/motiongfx_vello/src/vello_motion/mod.rs
@@ -1,2 +1,2 @@
-pub mod circle_motion;
-pub mod rect_motion;
+pub(crate) mod circle_motion;
+pub(crate) mod rect_motion;

--- a/crates/motiongfx_vello/src/vello_motion/rect_motion.rs
+++ b/crates/motiongfx_vello/src/vello_motion/rect_motion.rs
@@ -2,6 +2,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_math::DVec2;
 use bevy_vello_renderer::vello::kurbo;
+use motiongfx_bevy::prelude::*;
 use motiongfx_core::prelude::*;
 
 use crate::{
@@ -32,6 +33,7 @@ pub struct VelloRectBundleMotion {
     pub rect: VelloRectMotion,
     pub fill: FillStyleMotion,
     pub stroke: StrokeStyleMotion,
+    pub transform: TransformMotion,
 }
 
 impl VelloRectBundleMotion {
@@ -40,6 +42,7 @@ impl VelloRectBundleMotion {
             rect: VelloRectMotion::new(target_id, bundle.rect),
             fill: FillStyleMotion::new(target_id, bundle.fill),
             stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+            transform: TransformMotion::new(target_id, bundle.fragment_bundle.transform.local),
         }
     }
 }

--- a/crates/motiongfx_vello/src/vello_motion/rect_motion.rs
+++ b/crates/motiongfx_vello/src/vello_motion/rect_motion.rs
@@ -1,0 +1,263 @@
+use bevy_app::prelude::*;
+use bevy_ecs::prelude::*;
+use bevy_math::DVec2;
+use bevy_vello_renderer::vello::kurbo;
+use motiongfx_core::prelude::*;
+
+use crate::{
+    fill_style::FillStyleMotion,
+    stroke_style::StrokeStyleMotion,
+    vello_vector::{
+        rect::{VelloRect, VelloRectBundle},
+        VelloBuilder,
+    },
+};
+
+pub(crate) struct VelloRectMotionPlugin;
+
+impl Plugin for VelloRectMotionPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (
+                sequence_player_system::<VelloRect, kurbo::Rect, EmptyRes>,
+                sequence_player_system::<VelloRect, f64, EmptyRes>,
+                sequence_player_system::<VelloRect, kurbo::RoundedRectRadii, EmptyRes>,
+            ),
+        );
+    }
+}
+
+pub struct VelloRectBundleMotion {
+    pub rect: VelloRectMotion,
+    pub fill: FillStyleMotion,
+    pub stroke: StrokeStyleMotion,
+}
+
+impl VelloRectBundleMotion {
+    pub fn new(target_id: Entity, bundle: VelloRectBundle) -> Self {
+        Self {
+            rect: VelloRectMotion::new(target_id, bundle.rect),
+            fill: FillStyleMotion::new(target_id, bundle.fill),
+            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+        }
+    }
+}
+
+pub struct VelloRectMotion {
+    target_id: Entity,
+    vello_rect: VelloRect,
+}
+
+impl VelloRectMotion {
+    pub fn new(target_id: Entity, vello_rect: VelloRect) -> Self {
+        Self {
+            target_id,
+            vello_rect,
+        }
+    }
+
+    // =====================
+    // Rect
+    // =====================
+    pub fn inflate(
+        &mut self,
+        inflation: impl Into<DVec2>,
+    ) -> Action<VelloRect, kurbo::Rect, EmptyRes> {
+        let inflation: DVec2 = inflation.into();
+
+        let new_rect: kurbo::Rect = self.vello_rect.rect.inflate(inflation.x, inflation.y);
+
+        let action: Action<VelloRect, kurbo::Rect, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect,
+            new_rect,
+            Self::rect_interp,
+        );
+
+        self.vello_rect.rect = new_rect;
+
+        action
+    }
+
+    pub fn rect_to(
+        &mut self,
+        new_rect: impl Into<kurbo::Rect>,
+    ) -> Action<VelloRect, kurbo::Rect, EmptyRes> {
+        let new_rect: kurbo::Rect = new_rect.into();
+
+        let action: Action<VelloRect, kurbo::Rect, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect,
+            new_rect,
+            Self::rect_interp,
+        );
+
+        self.vello_rect.rect = new_rect;
+
+        action
+    }
+
+    fn rect_interp(
+        vello_rect: &mut VelloRect,
+        begin: &kurbo::Rect,
+        end: &kurbo::Rect,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.rect = kurbo::Rect::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+
+    // =====================
+    // Rect.x0
+    // =====================
+    /// Expand the left side of the rect.
+    pub fn expand_left(&mut self, expansion: f64) -> Action<VelloRect, f64, EmptyRes> {
+        let new_x0: f64 = self.vello_rect.rect.x0 - expansion;
+
+        let action: Action<VelloRect, f64, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect.x0,
+            new_x0,
+            Self::rect_x0_interp,
+        );
+
+        self.vello_rect.rect.x0 = new_x0;
+
+        action
+    }
+
+    fn rect_x0_interp(
+        vello_rect: &mut VelloRect,
+        begin: &f64,
+        end: &f64,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.rect.x0 = f64::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+
+    // =====================
+    // Rect.x1
+    // =====================
+    /// Expand the right side of the rect.
+    pub fn expand_right(&mut self, expansion: f64) -> Action<VelloRect, f64, EmptyRes> {
+        let new_x1: f64 = self.vello_rect.rect.x1 + expansion;
+
+        let action: Action<VelloRect, f64, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect.x1,
+            new_x1,
+            Self::rect_x1_interp,
+        );
+
+        self.vello_rect.rect.x1 = new_x1;
+
+        action
+    }
+
+    fn rect_x1_interp(
+        vello_rect: &mut VelloRect,
+        begin: &f64,
+        end: &f64,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.rect.x1 = f64::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+
+    // =====================
+    // Rect.y0
+    // =====================
+    /// Expand the bottom side of the rect.
+    pub fn expand_bottom(&mut self, expansion: f64) -> Action<VelloRect, f64, EmptyRes> {
+        let new_y0: f64 = self.vello_rect.rect.y0 - expansion;
+
+        let action: Action<VelloRect, f64, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect.y0,
+            new_y0,
+            Self::rect_y0_interp,
+        );
+
+        self.vello_rect.rect.y0 = new_y0;
+
+        action
+    }
+
+    fn rect_y0_interp(
+        vello_rect: &mut VelloRect,
+        begin: &f64,
+        end: &f64,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.rect.y0 = f64::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+
+    // =====================
+    // Rect.y1
+    // =====================
+    /// Expand the top side of the rect.
+    pub fn expand_top(&mut self, expansion: f64) -> Action<VelloRect, f64, EmptyRes> {
+        let new_y1: f64 = self.vello_rect.rect.y1 + expansion;
+
+        let action: Action<VelloRect, f64, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.rect.y1,
+            new_y1,
+            Self::rect_y1_interp,
+        );
+
+        self.vello_rect.rect.y1 = new_y1;
+
+        action
+    }
+
+    fn rect_y1_interp(
+        vello_rect: &mut VelloRect,
+        begin: &f64,
+        end: &f64,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.rect.y1 = f64::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+
+    // =====================
+    // Radii
+    // =====================
+    pub fn radii_to(
+        &mut self,
+        new_radii: impl Into<kurbo::RoundedRectRadii>,
+    ) -> Action<VelloRect, kurbo::RoundedRectRadii, EmptyRes> {
+        let new_radii: kurbo::RoundedRectRadii = new_radii.into();
+
+        let action: Action<VelloRect, kurbo::RoundedRectRadii, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_rect.radii,
+            new_radii,
+            Self::radii_interp,
+        );
+
+        self.vello_rect.radii = new_radii;
+
+        action
+    }
+
+    fn radii_interp(
+        vello_rect: &mut VelloRect,
+        begin: &kurbo::RoundedRectRadii,
+        end: &kurbo::RoundedRectRadii,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_rect.radii = kurbo::RoundedRectRadii::lerp(begin, end, t);
+        vello_rect.set_built(false);
+    }
+}

--- a/crates/motiongfx_vello/src/vello_vector/circle.rs
+++ b/crates/motiongfx_vello/src/vello_vector/circle.rs
@@ -154,13 +154,13 @@ impl VelloCircleMotion {
     }
 
     fn circle_interp(
-        vello_rect: &mut VelloCircle,
+        vello_circle: &mut VelloCircle,
         begin: &kurbo::Circle,
         end: &kurbo::Circle,
         t: f32,
         _: &mut ResMut<EmptyRes>,
     ) {
-        vello_rect.circle = kurbo::Circle::lerp(begin, end, t);
-        vello_rect.set_should_build(true);
+        vello_circle.circle = kurbo::Circle::lerp(begin, end, t);
+        vello_circle.set_should_build(true);
     }
 }

--- a/crates/motiongfx_vello/src/vello_vector/circle.rs
+++ b/crates/motiongfx_vello/src/vello_vector/circle.rs
@@ -5,11 +5,10 @@ use bevy_vello_renderer::{
     prelude::*,
     vello::{self, kurbo},
 };
-use motiongfx_core::prelude::*;
 
 use crate::{
-    fill_style::{FillStyle, FillStyleMotion},
-    stroke_style::{StrokeStyle, StrokeStyleMotion},
+    fill_style::FillStyle,
+    stroke_style::StrokeStyle,
     vello_vector::{VelloBuilder, VelloVector},
 };
 
@@ -21,26 +20,10 @@ pub struct VelloCircleBundle {
     pub fragment_bundle: VelloFragmentBundle,
 }
 
-pub struct VelloCircleBundleMotion {
-    pub circle: VelloCircleMotion,
-    pub fill: FillStyleMotion,
-    pub stroke: StrokeStyleMotion,
-}
-
-impl VelloCircleBundleMotion {
-    pub fn new(target_id: Entity, bundle: VelloCircleBundle) -> Self {
-        Self {
-            circle: VelloCircleMotion::new(target_id, bundle.circle),
-            fill: FillStyleMotion::new(target_id, bundle.fill),
-            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
-        }
-    }
-}
-
 #[derive(Component, Clone, Default)]
 pub struct VelloCircle {
-    circle: kurbo::Circle,
-    should_build: bool,
+    pub(crate) circle: kurbo::Circle,
+    built: bool,
 }
 
 impl VelloCircle {
@@ -93,74 +76,12 @@ impl VelloVector for VelloCircle {
 
 impl VelloBuilder for VelloCircle {
     #[inline]
-    fn should_build(&self) -> bool {
-        self.should_build
+    fn is_built(&self) -> bool {
+        self.built
     }
 
     #[inline]
-    fn set_should_build(&mut self, should_build: bool) {
-        self.should_build = should_build
-    }
-}
-
-pub struct VelloCircleMotion {
-    target_id: Entity,
-    vello_circle: VelloCircle,
-}
-
-impl VelloCircleMotion {
-    pub fn new(target_id: Entity, vello_circle: VelloCircle) -> Self {
-        Self {
-            target_id,
-            vello_circle,
-        }
-    }
-
-    // =====================
-    // Circle
-    // =====================
-    pub fn inflate(&mut self, inflation: f64) -> Action<VelloCircle, kurbo::Circle, EmptyRes> {
-        let mut new_circle: kurbo::Circle = self.vello_circle.circle;
-        new_circle.radius += inflation;
-
-        let action: Action<VelloCircle, kurbo::Circle, EmptyRes> = Action::new(
-            self.target_id,
-            self.vello_circle.circle,
-            new_circle,
-            Self::circle_interp,
-        );
-
-        self.vello_circle.circle = new_circle;
-
-        action
-    }
-
-    pub fn circle_to(
-        &mut self,
-        new_circle: impl Into<kurbo::Circle>,
-    ) -> Action<VelloCircle, kurbo::Circle, EmptyRes> {
-        let new_circle: kurbo::Circle = new_circle.into();
-
-        let action: Action<VelloCircle, kurbo::Circle, EmptyRes> = Action::new(
-            self.target_id,
-            self.vello_circle.circle,
-            new_circle,
-            Self::circle_interp,
-        );
-
-        self.vello_circle.circle = new_circle;
-
-        action
-    }
-
-    fn circle_interp(
-        vello_circle: &mut VelloCircle,
-        begin: &kurbo::Circle,
-        end: &kurbo::Circle,
-        t: f32,
-        _: &mut ResMut<EmptyRes>,
-    ) {
-        vello_circle.circle = kurbo::Circle::lerp(begin, end, t);
-        vello_circle.set_should_build(true);
+    fn set_built(&mut self, built: bool) {
+        self.built = built
     }
 }

--- a/crates/motiongfx_vello/src/vello_vector/line.rs
+++ b/crates/motiongfx_vello/src/vello_vector/line.rs
@@ -5,10 +5,9 @@ use bevy_vello_renderer::{
     prelude::*,
     vello::{self, kurbo},
 };
-use motiongfx_core::prelude::*;
 
 use crate::{
-    stroke_style::{StrokeStyle, StrokeStyleMotion},
+    stroke_style::StrokeStyle,
     vello_vector::{VelloBuilder, VelloVector},
 };
 
@@ -17,20 +16,6 @@ pub struct VelloLineBundle {
     pub line: VelloLine,
     pub stroke: StrokeStyle,
     pub fragment_bundle: VelloFragmentBundle,
-}
-
-pub struct VelloLineBundleMotion {
-    pub line: VelloLineMotion,
-    pub stroke: StrokeStyleMotion,
-}
-
-impl VelloLineBundleMotion {
-    pub fn new(target_id: Entity, bundle: VelloLineBundle) -> Self {
-        Self {
-            line: VelloLineMotion::new(target_id, bundle.line),
-            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
-        }
-    }
 }
 
 #[derive(Component, Clone)]
@@ -101,93 +86,5 @@ impl Default for VelloLine {
             line: kurbo::Line::new(kurbo::Point::default(), kurbo::Point::default()),
             built: false,
         }
-    }
-}
-
-pub struct VelloLineMotion {
-    target_id: Entity,
-    vello_line: VelloLine,
-}
-
-impl VelloLineMotion {
-    pub fn new(target_id: Entity, vello_line: VelloLine) -> Self {
-        Self {
-            target_id,
-            vello_line,
-        }
-    }
-
-    pub fn line_to(
-        &mut self,
-        new_line: impl Into<kurbo::Line>,
-    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
-        let new_line: kurbo::Line = new_line.into();
-
-        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
-            self.target_id,
-            self.vello_line.line,
-            new_line,
-            Self::line_interp,
-        );
-
-        self.vello_line.line = new_line;
-
-        action
-    }
-
-    /// Extend the line based on given `DVec2` percentage where `x` represents `p0` and `y` represents `p1`.
-    pub fn percentage_extend(
-        &mut self,
-        extension: f64,
-        percentage: impl Into<DVec2>,
-    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
-        let percentage: DVec2 = percentage.into();
-
-        let mut new_line: kurbo::Line = self.vello_line.line;
-        let direction: kurbo::Vec2 = self.get_p0_direction();
-
-        new_line.p0 += direction * extension * percentage.x;
-        new_line.p1 -= direction * extension * percentage.y;
-
-        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
-            self.target_id,
-            self.vello_line.line,
-            new_line,
-            Self::line_interp,
-        );
-
-        self.vello_line.line = new_line;
-
-        action
-    }
-
-    /// Extend the line only using `p0`.
-    pub fn extend_p0(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
-        self.percentage_extend(extension, DVec2::new(1.0, 0.0))
-    }
-
-    /// Extend the line only using `p1`.
-    pub fn extend_p1(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
-        self.percentage_extend(extension, DVec2::new(0.0, 1.0))
-    }
-
-    /// Extend the line on both `p0` and `p1`.
-    pub fn extend(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
-        self.percentage_extend(extension, DVec2::new(1.0, 1.0))
-    }
-
-    fn get_p0_direction(&self) -> kurbo::Vec2 {
-        (self.vello_line.line.p0 - self.vello_line.line.p1).normalize()
-    }
-
-    fn line_interp(
-        vello_line: &mut VelloLine,
-        begin: &kurbo::Line,
-        end: &kurbo::Line,
-        t: f32,
-        _: &mut ResMut<EmptyRes>,
-    ) {
-        vello_line.line = kurbo::Line::lerp(begin, end, t);
-        vello_line.set_built(false);
     }
 }

--- a/crates/motiongfx_vello/src/vello_vector/line.rs
+++ b/crates/motiongfx_vello/src/vello_vector/line.rs
@@ -1,0 +1,190 @@
+use bevy_ecs::prelude::*;
+use bevy_math::DVec2;
+use bevy_utils::prelude::*;
+use bevy_vello_renderer::{
+    prelude::*,
+    vello::{self, kurbo},
+};
+use motiongfx_core::prelude::*;
+
+use crate::{
+    stroke_style::{StrokeStyle, StrokeStyleMotion},
+    vello_vector::{VelloBuilder, VelloVector},
+};
+
+#[derive(Bundle, Clone, Default)]
+pub struct VelloLineBundle {
+    pub line: VelloLine,
+    pub stroke: StrokeStyle,
+    pub fragment_bundle: VelloFragmentBundle,
+}
+
+pub struct VelloLineBundleMotion {
+    pub line: VelloLineMotion,
+    pub stroke: StrokeStyleMotion,
+}
+
+impl VelloLineBundleMotion {
+    pub fn new(target_id: Entity, bundle: VelloLineBundle) -> Self {
+        Self {
+            line: VelloLineMotion::new(target_id, bundle.line),
+            stroke: StrokeStyleMotion::new(target_id, bundle.stroke),
+        }
+    }
+}
+
+#[derive(Component, Clone)]
+pub struct VelloLine {
+    line: kurbo::Line,
+    should_build: bool,
+}
+
+impl VelloLine {
+    #[inline]
+    pub fn new(line: impl Into<kurbo::Line>) -> Self {
+        let line: kurbo::Line = line.into();
+
+        Self { line, ..default() }
+    }
+
+    pub fn from_points(p0: impl Into<DVec2>, p1: impl Into<DVec2>) -> Self {
+        let p0: DVec2 = p0.into();
+        let p1: DVec2 = p1.into();
+
+        Self {
+            line: kurbo::Line::new(kurbo::Point::new(p0.x, p0.y), kurbo::Point::new(p1.x, p1.y)),
+            ..default()
+        }
+    }
+
+    pub fn origin_to(to: impl Into<DVec2>) -> Self {
+        let to: DVec2 = to.into();
+
+        Self {
+            line: kurbo::Line::new(kurbo::Point::default(), kurbo::Point::new(to.x, to.y)),
+            ..default()
+        }
+    }
+}
+
+impl VelloVector for VelloLine {
+    #[inline]
+    fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder) {
+        builder.stroke(
+            &stroke.style,
+            kurbo::Affine::default(),
+            &stroke.brush,
+            None,
+            &self.line,
+        );
+    }
+}
+
+impl VelloBuilder for VelloLine {
+    #[inline]
+    fn should_build(&self) -> bool {
+        self.should_build
+    }
+
+    #[inline]
+    fn set_should_build(&mut self, should_build: bool) {
+        self.should_build = should_build
+    }
+}
+
+impl Default for VelloLine {
+    fn default() -> Self {
+        Self {
+            line: kurbo::Line::new(kurbo::Point::default(), kurbo::Point::default()),
+            should_build: false,
+        }
+    }
+}
+
+pub struct VelloLineMotion {
+    target_id: Entity,
+    vello_line: VelloLine,
+}
+
+impl VelloLineMotion {
+    pub fn new(target_id: Entity, vello_line: VelloLine) -> Self {
+        Self {
+            target_id,
+            vello_line,
+        }
+    }
+
+    pub fn line_to(
+        &mut self,
+        new_line: impl Into<kurbo::Line>,
+    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        let new_line: kurbo::Line = new_line.into();
+
+        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_line.line,
+            new_line,
+            Self::line_interp,
+        );
+
+        self.vello_line.line = new_line;
+
+        action
+    }
+
+    /// Extend the line based on given `DVec2` percentage where `x` represents `p0` and `y` represents `p1`.
+    pub fn percentage_extend(
+        &mut self,
+        extension: f64,
+        percentage: impl Into<DVec2>,
+    ) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        let percentage: DVec2 = percentage.into();
+
+        let mut new_line: kurbo::Line = self.vello_line.line;
+        let direction: kurbo::Vec2 = self.get_p0_direction();
+
+        new_line.p0 += direction * extension * percentage.x;
+        new_line.p1 -= direction * extension * percentage.y;
+
+        let action: Action<VelloLine, kurbo::Line, EmptyRes> = Action::new(
+            self.target_id,
+            self.vello_line.line,
+            new_line,
+            Self::line_interp,
+        );
+
+        self.vello_line.line = new_line;
+
+        action
+    }
+
+    /// Extend the line only using `p0`.
+    pub fn extend_p0(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(1.0, 0.0))
+    }
+
+    /// Extend the line only using `p1`.
+    pub fn extend_p1(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(0.0, 1.0))
+    }
+
+    /// Extend the line on both `p0` and `p1`.
+    pub fn extend(&mut self, extension: f64) -> Action<VelloLine, kurbo::Line, EmptyRes> {
+        self.percentage_extend(extension, DVec2::new(1.0, 1.0))
+    }
+
+    fn get_p0_direction(&self) -> kurbo::Vec2 {
+        (self.vello_line.line.p0 - self.vello_line.line.p1).normalize()
+    }
+
+    fn line_interp(
+        vello_line: &mut VelloLine,
+        begin: &kurbo::Line,
+        end: &kurbo::Line,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        vello_line.line = kurbo::Line::lerp(begin, end, t);
+        vello_line.set_should_build(true);
+    }
+}

--- a/crates/motiongfx_vello/src/vello_vector/line.rs
+++ b/crates/motiongfx_vello/src/vello_vector/line.rs
@@ -35,8 +35,8 @@ impl VelloLineBundleMotion {
 
 #[derive(Component, Clone)]
 pub struct VelloLine {
-    line: kurbo::Line,
-    should_build: bool,
+    pub(crate) line: kurbo::Line,
+    built: bool,
 }
 
 impl VelloLine {
@@ -69,6 +69,9 @@ impl VelloLine {
 
 impl VelloVector for VelloLine {
     #[inline]
+    fn build_fill(&self, _: &crate::fill_style::FillStyle, _: &mut vello::SceneBuilder) {}
+
+    #[inline]
     fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder) {
         builder.stroke(
             &stroke.style,
@@ -82,13 +85,13 @@ impl VelloVector for VelloLine {
 
 impl VelloBuilder for VelloLine {
     #[inline]
-    fn should_build(&self) -> bool {
-        self.should_build
+    fn is_built(&self) -> bool {
+        self.built
     }
 
     #[inline]
-    fn set_should_build(&mut self, should_build: bool) {
-        self.should_build = should_build
+    fn set_built(&mut self, built: bool) {
+        self.built = built
     }
 }
 
@@ -96,7 +99,7 @@ impl Default for VelloLine {
     fn default() -> Self {
         Self {
             line: kurbo::Line::new(kurbo::Point::default(), kurbo::Point::default()),
-            should_build: false,
+            built: false,
         }
     }
 }
@@ -185,6 +188,6 @@ impl VelloLineMotion {
         _: &mut ResMut<EmptyRes>,
     ) {
         vello_line.line = kurbo::Line::lerp(begin, end, t);
-        vello_line.set_should_build(true);
+        vello_line.set_built(false);
     }
 }

--- a/crates/motiongfx_vello/src/vello_vector/mod.rs
+++ b/crates/motiongfx_vello/src/vello_vector/mod.rs
@@ -6,12 +6,13 @@ use crate::fill_style::FillStyle;
 use crate::stroke_style::StrokeStyle;
 
 pub mod circle;
+pub mod line;
 pub mod rect;
 
 pub(crate) trait VelloVector {
-    fn build_fill(&self, fill: &FillStyle, builder: &mut vello::SceneBuilder);
+    fn build_fill(&self, fill: &FillStyle, builder: &mut vello::SceneBuilder) {}
 
-    fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder);
+    fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder) {}
 }
 
 pub(crate) trait VelloBuilder {

--- a/crates/motiongfx_vello/src/vello_vector/mod.rs
+++ b/crates/motiongfx_vello/src/vello_vector/mod.rs
@@ -10,15 +10,15 @@ pub mod line;
 pub mod rect;
 
 pub(crate) trait VelloVector {
-    fn build_fill(&self, fill: &FillStyle, builder: &mut vello::SceneBuilder) {}
+    fn build_fill(&self, fill: &FillStyle, builder: &mut vello::SceneBuilder);
 
-    fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder) {}
+    fn build_stroke(&self, stroke: &StrokeStyle, builder: &mut vello::SceneBuilder);
 }
 
 pub(crate) trait VelloBuilder {
-    fn should_build(&self) -> bool;
+    fn is_built(&self) -> bool;
 
-    fn set_should_build(&mut self, should_build: bool);
+    fn set_built(&mut self, should_build: bool);
 }
 
 pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
@@ -43,7 +43,7 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             let mut frag: vello::SceneFragment = vello::SceneFragment::new();
             let mut builder: vello::SceneBuilder = vello::SceneBuilder::for_fragment(&mut frag);
 
-            if vector.should_build() == false && fill.should_build() == false {
+            if vector.is_built() && fill.is_built() {
                 continue;
             }
 
@@ -51,8 +51,8 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             vector.build_fill(&fill, &mut builder);
 
             // Set it to false after building
-            fill.set_should_build(false);
-            vector.set_should_build(false);
+            fill.set_built(true);
+            vector.set_built(true);
 
             // Replace with new fragment
             fragment.fragment = frag.into();
@@ -64,7 +64,7 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             let mut frag: vello::SceneFragment = vello::SceneFragment::new();
             let mut builder: vello::SceneBuilder = vello::SceneBuilder::for_fragment(&mut frag);
 
-            if vector.should_build() == false && stroke.should_build() == false {
+            if vector.is_built() && stroke.is_built() {
                 continue;
             }
 
@@ -72,8 +72,8 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             vector.build_stroke(&stroke, &mut builder);
 
             // Set it to false after building
-            stroke.set_should_build(false);
-            vector.set_should_build(false);
+            stroke.set_built(true);
+            vector.set_built(true);
 
             // Replace with new fragment
             fragment.fragment = frag.into();
@@ -86,10 +86,7 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             let mut frag: vello::SceneFragment = vello::SceneFragment::new();
             let mut builder: vello::SceneBuilder = vello::SceneBuilder::for_fragment(&mut frag);
 
-            if vector.should_build() == false
-                && fill.should_build() == false
-                && stroke.should_build() == false
-            {
+            if vector.is_built() && fill.is_built() && stroke.is_built() {
                 continue;
             }
 
@@ -98,9 +95,9 @@ pub(crate) fn vector_builder<Vector: VelloVector + VelloBuilder + Component>(
             vector.build_stroke(&stroke, &mut builder);
 
             // Set it to false after building
-            fill.set_should_build(false);
-            stroke.set_should_build(false);
-            vector.set_should_build(false);
+            fill.set_built(true);
+            stroke.set_built(true);
+            vector.set_built(true);
 
             // Replace with new fragment
             fragment.fragment = frag.into();

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -7,7 +7,8 @@ use motiongfx_vello::{
     bevy_vello_renderer::prelude::*,
     fill_style::FillStyle,
     stroke_style::StrokeStyle,
-    vello_vector::rect::{VelloRect, VelloRectBundle, VelloRectBundleMotion},
+    vello_motion::rect_motion::VelloRectBundleMotion,
+    vello_vector::rect::{VelloRect, VelloRectBundle},
 };
 
 fn main() {
@@ -30,104 +31,31 @@ fn vello_basic(
     mut fragments: ResMut<Assets<VelloFragment>>,
     mut sequence: ResMut<Sequence>,
 ) {
-    const RECT_COUNT: usize = 14;
-    const RECT_SIZE: f32 = 40.0;
-    const SPACING: f32 = 5.0;
-
     // Color palette
     let palette: ColorPalette<ColorKey> = ColorPalette::default();
 
-    let mut rect_motions: Vec<VelloRectBundleMotion> = Vec::with_capacity(RECT_COUNT);
-    let mut transform_motions: Vec<TransformMotion> = Vec::with_capacity(RECT_COUNT);
-
-    let start_y: f32 = (RECT_COUNT as f32) * 0.5 * (RECT_SIZE + SPACING);
-
-    for r in 0..RECT_COUNT {
-        let transform: Transform = Transform::from_translation(Vec3::new(
-            -500.0,
-            start_y - (r as f32) * (RECT_SIZE + SPACING),
-            0.0,
-        ));
-
-        let rect_bundle: VelloRectBundle = VelloRectBundle {
-            rect: VelloRect::anchor_center(DVec2::new(0.0, 0.0), DVec4::splat(10.0)),
-            fragment_bundle: VelloFragmentBundle {
-                fragment: fragments.add(VelloFragment::default()),
-                transform: TransformBundle::from_transform(transform),
-                ..default()
-            },
-            fill: FillStyle::from_brush(*palette.get_or_default(&ColorKey::Base4)),
-            stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Base6)),
+    let rect_bundle: VelloRectBundle = VelloRectBundle {
+        rect: VelloRect::anchor_center(DVec2::new(100.0, 100.0), DVec4::splat(10.0)),
+        fill: FillStyle::from_brush(*palette.get_or_default(&ColorKey::Blue)),
+        stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Base8)).with_style(4.0),
+        fragment_bundle: VelloFragmentBundle {
+            fragment: fragments.add(VelloFragment::default()),
+            transform: TransformBundle::from_transform(Transform::from_xyz(-100.0, 0.0, 0.0)),
             ..default()
-        };
+        },
+    };
 
-        let fragment_id: Entity = commands.spawn(rect_bundle.clone()).id();
+    let fragment_id: Entity = commands.spawn(rect_bundle.clone()).id();
 
-        rect_motions.push(VelloRectBundleMotion::new(fragment_id, rect_bundle));
-        transform_motions.push(TransformMotion::new(fragment_id, transform));
-    }
-
-    // ACTIONS
+    // Actions
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
-    let mut inflate_actions: Vec<ActionMetaGroup> = Vec::with_capacity(RECT_COUNT);
-    let mut expand_right_actions: Vec<ActionMetaGroup> = Vec::with_capacity(RECT_COUNT);
-    let mut expand_left_actions: Vec<ActionMetaGroup> = Vec::with_capacity(RECT_COUNT);
-    let mut transform_actions: Vec<ActionMetaGroup> = Vec::with_capacity(RECT_COUNT);
-    let mut fill_actions: Vec<ActionMetaGroup> = Vec::with_capacity(RECT_COUNT);
-
-    for r in 0..RECT_COUNT {
-        let expansion: f64 = 900.0 * (r as f64) / (RECT_COUNT as f64) + 100.0;
-
-        inflate_actions.push(
-            act.play(
-                rect_motions[r].rect.inflate(Vec2::splat(RECT_SIZE * 0.5)),
-                1.0,
-            )
-            .with_ease(ease::expo::ease_in_out),
-        );
-        expand_right_actions.push(
-            act.play(rect_motions[r].rect.expand_right(expansion), 1.0)
-                .with_ease(ease::expo::ease_in_out),
-        );
-        expand_left_actions.push(
-            act.play(rect_motions[r].rect.expand_left(-expansion), 1.0)
-                .with_ease(ease::expo::ease_in_out),
-        );
-
-        let mut translation: Vec3 = transform_motions[r].get_transform().translation;
-        translation.y = 0.0;
-        transform_actions.push(
-            act.play(transform_motions[r].translate_to(translation), 1.0)
-                .with_ease(ease::back::ease_in_out),
-        );
-
-        let color: Color = Color::lerp(
-            palette.get_or_default(&ColorKey::Purple),
-            palette.get_or_default(&ColorKey::Blue),
-            (r as f32) / (RECT_COUNT as f32),
-        );
-
-        fill_actions.push(all(&[
-            act.play(rect_motions[r].fill.brush_to(color), 1.0),
-            act.play(rect_motions[r].stroke.brush_to(color * 1.2), 1.0),
-            act.play(rect_motions[r].stroke.style_to(5.0), 1.0),
-        ]));
-    }
-
-    sequence.play(flow(
-        1.0,
-        &[
-            flow(0.1, &inflate_actions),
-            flow(0.1, &expand_right_actions),
-            flow(0.1, &expand_left_actions),
-            all(&[flow(0.1, &transform_actions), flow(0.1, &fill_actions)]),
-        ],
-    ));
+    // sequence.play();
 }
 
 fn timeline_movement_system(
     mut timeline: ResMut<Timeline>,
+    sequence: Res<Sequence>,
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
@@ -137,6 +65,13 @@ fn timeline_movement_system(
 
     if keys.pressed(KeyCode::A) {
         timeline.target_time -= time.delta_seconds();
+    }
+
+    // Ping pong animation while playing
+    if timeline.is_playing
+        && (timeline.target_time <= 0.0 || timeline.target_time >= sequence.duration())
+    {
+        timeline.time_scale *= -1.0;
     }
 
     if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -41,7 +41,7 @@ fn vello_basic(
         },
     };
 
-    let circle_bundle: VelloCircleBundle = VelloCircleBundle {
+    let circ_bundle: VelloCircleBundle = VelloCircleBundle {
         circle: VelloCircle::from_radius(50.0),
         fill: FillStyle::from_brush(*palette.get_or_default(&ColorKey::Purple)),
         stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Purple) * 1.5)
@@ -53,13 +53,25 @@ fn vello_basic(
         },
     };
 
+    let line_bundle: VelloLineBundle = VelloLineBundle {
+        line: VelloLine::from_points(DVec2::new(-300.0, 0.0), DVec2::new(300.0, 0.0)),
+        stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Base8)),
+        fragment_bundle: VelloFragmentBundle {
+            fragment: fragments.add(VelloFragment::default()),
+            transform: TransformBundle::from_transform(Transform::from_xyz(0.0, -100.0, 0.0)),
+            ..default()
+        },
+    };
+
     let rect_id: Entity = commands.spawn(rect_bundle.clone()).id();
-    let circ_id: Entity = commands.spawn(circle_bundle.clone()).id();
+    let circ_id: Entity = commands.spawn(circ_bundle.clone()).id();
+    let line_id: Entity = commands.spawn(line_bundle.clone()).id();
 
     // Motions
     let mut rect_motion: VelloRectBundleMotion = VelloRectBundleMotion::new(rect_id, rect_bundle);
     let mut circ_motion: VelloCircleBundleMotion =
-        VelloCircleBundleMotion::new(circ_id, circle_bundle);
+        VelloCircleBundleMotion::new(circ_id, circ_bundle);
+    let mut line_motion: VelloLineBundleMotion = VelloLineBundleMotion::new(line_id, line_bundle);
 
     // Actions
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
@@ -67,7 +79,27 @@ fn vello_basic(
     let actions: ActionMetaGroup = flow(
         0.5,
         &[
-            // Rect animation
+            // Line animation
+            chain(&[
+                all(&[
+                    act.play(
+                        line_motion
+                            .transform
+                            .translate_add(Vec3::new(0.0, -100.0, 0.0)),
+                        1.5,
+                    ),
+                    act.play(line_motion.line.extend(100.0), 1.0),
+                ]),
+                all(&[
+                    act.play(
+                        line_motion
+                            .transform
+                            .translate_add(Vec3::new(0.0, 100.0, 0.0)),
+                        1.5,
+                    ),
+                    act.play(line_motion.line.extend(-100.0), 1.0),
+                ]),
+            ]), // Rect animation
             chain(&[
                 all(&[
                     act.play(rect_motion.rect.inflate(DVec2::splat(50.0)), 1.0),

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -3,13 +3,7 @@ use bevy::{
     prelude::*,
 };
 use bevy_motiongfx::prelude::*;
-use motiongfx_vello::{
-    bevy_vello_renderer::prelude::*,
-    fill_style::FillStyle,
-    stroke_style::StrokeStyle,
-    vello_motion::rect_motion::VelloRectBundleMotion,
-    vello_vector::rect::{VelloRect, VelloRectBundle},
-};
+use motiongfx_vello::prelude::*;
 
 fn main() {
     App::new()
@@ -37,15 +31,34 @@ fn vello_basic(
     let rect_bundle: VelloRectBundle = VelloRectBundle {
         rect: VelloRect::anchor_center(DVec2::new(100.0, 100.0), DVec4::splat(10.0)),
         fill: FillStyle::from_brush(*palette.get_or_default(&ColorKey::Blue)),
-        stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Base8)).with_style(4.0),
+        stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Blue) * 1.5)
+            .with_style(4.0),
         fragment_bundle: VelloFragmentBundle {
             fragment: fragments.add(VelloFragment::default()),
-            transform: TransformBundle::from_transform(Transform::from_xyz(-100.0, 0.0, 0.0)),
+            transform: TransformBundle::from_transform(Transform::from_xyz(-200.0, 0.0, 0.0)),
             ..default()
         },
     };
 
-    let fragment_id: Entity = commands.spawn(rect_bundle.clone()).id();
+    let circle_bundle: VelloCircleBundle = VelloCircleBundle {
+        circle: VelloCircle::from_radius(50.0),
+        fill: FillStyle::from_brush(*palette.get_or_default(&ColorKey::Purple)),
+        stroke: StrokeStyle::from_brush(*palette.get_or_default(&ColorKey::Purple) * 1.5)
+            .with_style(4.0),
+        fragment_bundle: VelloFragmentBundle {
+            fragment: fragments.add(VelloFragment::default()),
+            transform: TransformBundle::default(),
+            ..default()
+        },
+    };
+
+    let rect_id: Entity = commands.spawn(rect_bundle.clone()).id();
+    let circle_id: Entity = commands.spawn(circle_bundle.clone()).id();
+
+    // Motions
+    let rect_motion: VelloRectBundleMotion = VelloRectBundleMotion::new(rect_id, rect_bundle);
+    let circle_motion: VelloCircleBundleMotion =
+        VelloCircleBundleMotion::new(circle_id, circle_bundle);
 
     // Actions
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);


### PR DESCRIPTION
Related to https://github.com/nixon-voxell/bevy_motiongfx/issues/3

This pull request focuses on basic line shape animation and creation + some core Vello API improvements.

- Use `built` check instead of `should_build` check
- Separation of Motion and Shape creation into 2 different folders (`vello_vector` & `vello_motion`)
- Change most mods default to private to hide some crate usage only members.
- Introduction of motion plugins.
- Addition of `VelloLine` (alongside with motion, bundle, and motion bundle)