### PR TITLE
6 timeline as a component

### DIFF
--- a/crates/motiongfx_core/src/action.rs
+++ b/crates/motiongfx_core/src/action.rs
@@ -1,6 +1,10 @@
-use crate::ease::{quad, EaseFn};
 use bevy_ecs::prelude::*;
 use bevy_utils::prelude::*;
+
+use crate::{
+    ease::{quad, EaseFn},
+    sequence::Sequence,
+};
 
 pub type InterpFn<CompType, InterpType, ResType> = fn(
     component: &mut CompType,
@@ -54,9 +58,9 @@ pub struct ActionMeta {
     /// Target `Entity` for `Action`.
     action_id: Entity,
     /// Time at which animation should begin.
-    start_time: f32,
+    pub(crate) start_time: f32,
     /// Duration of animation in seconds.
-    duration: f32,
+    pub(crate) duration: f32,
     /// Easing function to be used for animation.
     pub(crate) ease_fn: EaseFn,
 }
@@ -75,14 +79,14 @@ impl ActionMeta {
         self.action_id
     }
 
-    #[inline]
-    pub fn with_start_time(mut self, start_time: f32) -> Self {
-        self.start_time = start_time;
-        self
-    }
+    // #[inline]
+    // pub fn with_start_time(mut self, start_time: f32) -> Self {
+    //     self.start_time = start_time;
+    //     self
+    // }
 
     #[inline]
-    pub fn with_duration(mut self, duration: f32) -> Self {
+    fn with_duration(mut self, duration: f32) -> Self {
         self.duration = duration;
         self
     }
@@ -93,20 +97,20 @@ impl ActionMeta {
         self
     }
 
-    #[inline]
-    pub fn start_time(&self) -> f32 {
-        self.start_time
-    }
+    // #[inline]
+    // pub fn start_time(&self) -> f32 {
+    //     self.start_time
+    // }
 
     #[inline]
     pub fn end_time(&self) -> f32 {
         self.start_time + self.duration
     }
 
-    #[inline]
-    pub fn duration(&self) -> f32 {
-        self.duration
-    }
+    // #[inline]
+    // pub fn duration(&self) -> f32 {
+    //     self.duration
+    // }
 }
 
 pub struct ActionBuilder<'a, 'w, 's> {
@@ -129,8 +133,26 @@ impl<'a, 'w, 's> ActionBuilder<'a, 'w, 's> {
         ActionMetaGroup::single(action_meta)
     }
 
+    pub fn play_sequence(
+        &mut self,
+        action: Action<impl Component, impl Send + Sync + 'static, impl Resource>,
+        duration: f32,
+    ) -> Sequence {
+        let action_id: Entity = self.commands.spawn(action).id();
+        let action_meta: ActionMeta = ActionMeta::new(action_id).with_duration(duration);
+
+        Sequence::single(action_meta)
+    }
+
     pub fn sleep(&mut self, duration: f32) -> ActionMetaGroup {
         ActionMetaGroup {
+            duration,
+            ..default()
+        }
+    }
+
+    pub fn sleep_sequence(&mut self, duration: f32) -> Sequence {
+        Sequence {
             duration,
             ..default()
         }
@@ -147,7 +169,7 @@ pub struct ActionMetaGroup {
 impl ActionMetaGroup {
     /// Create an `ActionMetaGroup` with only a single `ActionMeta` in it.
     pub fn single(action_meta: ActionMeta) -> Self {
-        let duration: f32 = action_meta.duration();
+        let duration: f32 = action_meta.duration;
 
         Self {
             action_metas: vec![action_meta],

--- a/crates/motiongfx_core/src/action.rs
+++ b/crates/motiongfx_core/src/action.rs
@@ -54,7 +54,7 @@ where
 }
 
 #[derive(Clone)]
-pub struct ActionMeta {
+pub(crate) struct ActionMeta {
     /// Target `Entity` for `Action`.
     action_id: Entity,
     /// Time at which animation should begin.
@@ -79,38 +79,10 @@ impl ActionMeta {
         self.action_id
     }
 
-    // #[inline]
-    // pub fn with_start_time(mut self, start_time: f32) -> Self {
-    //     self.start_time = start_time;
-    //     self
-    // }
-
-    #[inline]
-    fn with_duration(mut self, duration: f32) -> Self {
-        self.duration = duration;
-        self
-    }
-
-    #[inline]
-    pub fn with_ease(mut self, ease_fn: EaseFn) -> Self {
-        self.ease_fn = ease_fn;
-        self
-    }
-
-    // #[inline]
-    // pub fn start_time(&self) -> f32 {
-    //     self.start_time
-    // }
-
     #[inline]
     pub fn end_time(&self) -> f32 {
         self.start_time + self.duration
     }
-
-    // #[inline]
-    // pub fn duration(&self) -> f32 {
-    //     self.duration
-    // }
 }
 
 pub struct ActionBuilder<'a, 'w, 's> {
@@ -126,62 +98,18 @@ impl<'a, 'w, 's> ActionBuilder<'a, 'w, 's> {
         &mut self,
         action: Action<impl Component, impl Send + Sync + 'static, impl Resource>,
         duration: f32,
-    ) -> ActionMetaGroup {
-        let action_id: Entity = self.commands.spawn(action).id();
-        let action_meta: ActionMeta = ActionMeta::new(action_id).with_duration(duration);
-
-        ActionMetaGroup::single(action_meta)
-    }
-
-    pub fn play_sequence(
-        &mut self,
-        action: Action<impl Component, impl Send + Sync + 'static, impl Resource>,
-        duration: f32,
     ) -> Sequence {
         let action_id: Entity = self.commands.spawn(action).id();
-        let action_meta: ActionMeta = ActionMeta::new(action_id).with_duration(duration);
+        let mut action_meta: ActionMeta = ActionMeta::new(action_id);
+        action_meta.duration = duration;
 
         Sequence::single(action_meta)
     }
 
-    pub fn sleep(&mut self, duration: f32) -> ActionMetaGroup {
-        ActionMetaGroup {
-            duration,
-            ..default()
-        }
-    }
-
-    pub fn sleep_sequence(&mut self, duration: f32) -> Sequence {
+    pub fn sleep(&mut self, duration: f32) -> Sequence {
         Sequence {
             duration,
             ..default()
         }
-    }
-}
-
-// FIXME: use Sequence instead??
-#[derive(Clone, Default)]
-pub struct ActionMetaGroup {
-    pub(crate) action_metas: Vec<ActionMeta>,
-    pub(crate) duration: f32,
-}
-
-impl ActionMetaGroup {
-    /// Create an `ActionMetaGroup` with only a single `ActionMeta` in it.
-    pub fn single(action_meta: ActionMeta) -> Self {
-        let duration: f32 = action_meta.duration;
-
-        Self {
-            action_metas: vec![action_meta],
-            duration,
-        }
-    }
-
-    pub fn with_ease(mut self, ease_fn: EaseFn) -> Self {
-        for action_meta in &mut self.action_metas {
-            action_meta.ease_fn = ease_fn;
-        }
-
-        self
     }
 }

--- a/crates/motiongfx_core/src/lib.rs
+++ b/crates/motiongfx_core/src/lib.rs
@@ -26,9 +26,7 @@ pub struct MotionGfx;
 
 impl Plugin for MotionGfx {
     fn build(&self, app: &mut App) {
-        app.insert_resource(timeline::Timeline::default())
-            .insert_resource(sequence::Sequence::default())
-            .insert_resource(EmptyRes)
+        app.insert_resource(EmptyRes)
             .add_systems(PreUpdate, timeline::timeline_update_system);
     }
 }

--- a/crates/motiongfx_core/src/lib.rs
+++ b/crates/motiongfx_core/src/lib.rs
@@ -11,7 +11,7 @@ pub mod timeline;
 
 pub mod prelude {
     pub use crate::{
-        action::{Action, ActionBuilder, ActionMeta, ActionMetaGroup},
+        action::{Action, ActionBuilder},
         color_palette::{ColorKey, ColorPalette},
         cross_lerp::*,
         ease,

--- a/crates/motiongfx_core/src/sequence.rs
+++ b/crates/motiongfx_core/src/sequence.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A vector of [`ActionMeta`]s.
-#[derive(Resource, Default, Component)]
+#[derive(Resource, Component, Default)]
 pub struct Sequence {
     pub(crate) duration: f32,
     pub(crate) action_metas: Vec<ActionMeta>,
@@ -134,7 +134,7 @@ pub fn delay(delay: f32, mut sequence: Sequence) -> Sequence {
         action_meta.start_time += delay;
     }
 
-    sequence.duration = delay + sequence.duration;
+    sequence.duration += delay;
     sequence
 }
 
@@ -152,7 +152,7 @@ pub fn sequence_player_system<CompType, InterpType, ResType>(
 {
     // Do not perform any actions if there are no changes to the timeline timings
     // or there are no actions at all.
-    if timeline.curr_time == timeline.target_time || scene.action_metas.len() == 0 {
+    if timeline.curr_time == timeline.target_time || scene.action_metas.is_empty() {
         return;
     }
 

--- a/crates/motiongfx_core/src/sequence.rs
+++ b/crates/motiongfx_core/src/sequence.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy_ecs::prelude::*;
 
 /// A vector of [`ActionMeta`]s.
-#[derive(Resource, Default)]
+#[derive(Resource, Default, Component)]
 pub struct Sequence {
     duration: f32,
     action_metas: Vec<ActionMeta>,
@@ -20,6 +20,25 @@ impl Sequence {
         let mut max_duration: f32 = 0.0;
 
         for action_meta in action_grp.action_metas {
+            self.action_metas.push(
+                action_meta
+                    .clone()
+                    .with_start_time(action_meta.start_time() + self.duration),
+            );
+
+            max_duration = f32::max(
+                max_duration,
+                action_meta.start_time() + action_meta.duration(),
+            );
+        }
+
+        self.duration = max_duration;
+    }
+
+    pub fn play_sequence(&mut self, sequence: Self) {
+        let mut max_duration: f32 = 0.0;
+
+        for action_meta in sequence.action_metas {
             self.action_metas.push(
                 action_meta
                     .clone()

--- a/crates/motiongfx_core/src/sequence.rs
+++ b/crates/motiongfx_core/src/sequence.rs
@@ -6,7 +6,7 @@ use crate::{
     timeline::Timeline,
 };
 
-/// A vector of [`ActionMeta`]s.
+/// A group of actions in chronological order.
 #[derive(Component, Default)]
 pub struct Sequence {
     pub(crate) duration: f32,

--- a/crates/motiongfx_core/src/timeline.rs
+++ b/crates/motiongfx_core/src/timeline.rs
@@ -21,7 +21,7 @@ impl Timeline {
         }
     }
 
-    /// Create an action from a timeline.
+    /// Create an [`Action`] from a [`Timeline`].
     pub fn to_action(&self, begin: f32, end: f32) -> Option<Action<Timeline, f32, EmptyRes>> {
         let Some(sequence_id) = self.sequence_id else {
             return None;

--- a/crates/motiongfx_core/src/timeline.rs
+++ b/crates/motiongfx_core/src/timeline.rs
@@ -4,9 +4,9 @@ use bevy_utils::prelude::*;
 
 use crate::sequence::Sequence;
 
-#[derive(Resource, Component)]
+#[derive(Component)]
 pub struct Timeline {
-    pub(crate) target_sequence: Option<Entity>,
+    pub(crate) sequence_id: Option<Entity>,
     pub(crate) curr_time: f32,
     pub is_playing: bool,
     pub time_scale: f32,
@@ -14,9 +14,9 @@ pub struct Timeline {
 }
 
 impl Timeline {
-    pub fn new(target_sequence: Entity) -> Self {
+    pub fn new(sequence_id: Entity) -> Self {
         Self {
-            target_sequence: Some(target_sequence),
+            sequence_id: Some(sequence_id),
             ..default()
         }
     }
@@ -25,7 +25,7 @@ impl Timeline {
 impl Default for Timeline {
     fn default() -> Self {
         Self {
-            target_sequence: None,
+            sequence_id: None,
             curr_time: 0.0,
             is_playing: false,
             time_scale: 1.0,
@@ -36,27 +36,12 @@ impl Default for Timeline {
 
 /// Safely update the timings in the `Timeline` after performing all the necessary actions.
 pub(crate) fn timeline_update_system(
-    mut timeline: ResMut<Timeline>,
-    sequence: Res<Sequence>,
-    time: Res<Time>,
-) {
-    timeline.curr_time = timeline.target_time;
-
-    if timeline.is_playing {
-        timeline.target_time += time.delta_seconds() * timeline.time_scale;
-    }
-
-    timeline.target_time = f32::clamp(timeline.target_time, 0.0, sequence.duration);
-}
-
-/// Safely update the timings in the `Timeline` after performing all the necessary actions.
-pub(crate) fn _timeline_update_system(
     q_sequences: Query<&Sequence>,
     mut q_timelines: Query<&mut Timeline>,
     time: Res<Time>,
 ) {
     for mut timeline in q_timelines.iter_mut() {
-        let Some(target_sequence) = timeline.target_sequence else {
+        let Some(target_sequence) = timeline.sequence_id else {
             return;
         };
 

--- a/crates/motiongfx_core/src/timeline.rs
+++ b/crates/motiongfx_core/src/timeline.rs
@@ -2,7 +2,7 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 use bevy_utils::prelude::*;
 
-use crate::sequence::Sequence;
+use crate::{action::Action, lerp::*, sequence::Sequence, EmptyRes};
 
 #[derive(Component)]
 pub struct Timeline {
@@ -19,6 +19,25 @@ impl Timeline {
             sequence_id: Some(sequence_id),
             ..default()
         }
+    }
+
+    /// Create an action from a timeline.
+    pub fn to_action(&self, begin: f32, end: f32) -> Option<Action<Timeline, f32, EmptyRes>> {
+        let Some(sequence_id) = self.sequence_id else {
+            return None;
+        };
+
+        Some(Action::new(sequence_id, begin, end, Self::timeline_interp))
+    }
+
+    fn timeline_interp(
+        timeline: &mut Timeline,
+        begin: &f32,
+        end: &f32,
+        t: f32,
+        _: &mut ResMut<EmptyRes>,
+    ) {
+        timeline.target_time = f32::lerp(begin, end, t);
     }
 }
 

--- a/crates/motiongfx_core/src/timeline.rs
+++ b/crates/motiongfx_core/src/timeline.rs
@@ -1,21 +1,34 @@
-use crate::sequence::Sequence;
 use bevy_ecs::prelude::*;
 use bevy_time::Time;
+use bevy_utils::prelude::*;
 
-#[derive(Resource)]
+use crate::sequence::Sequence;
+
+#[derive(Resource, Component)]
 pub struct Timeline {
+    pub(crate) target_sequence: Option<Entity>,
+    pub(crate) curr_time: f32,
     pub is_playing: bool,
     pub time_scale: f32,
-    pub curr_time: f32,
     pub target_time: f32,
+}
+
+impl Timeline {
+    pub fn new(target_sequence: Entity) -> Self {
+        Self {
+            target_sequence: Some(target_sequence),
+            ..default()
+        }
+    }
 }
 
 impl Default for Timeline {
     fn default() -> Self {
         Self {
+            target_sequence: None,
+            curr_time: 0.0,
             is_playing: false,
             time_scale: 1.0,
-            curr_time: 0.0,
             target_time: 0.0,
         }
     }
@@ -33,5 +46,30 @@ pub(crate) fn timeline_update_system(
         timeline.target_time += time.delta_seconds() * timeline.time_scale;
     }
 
-    timeline.target_time = f32::clamp(timeline.target_time, 0.0, sequence.duration());
+    timeline.target_time = f32::clamp(timeline.target_time, 0.0, sequence.duration);
+}
+
+/// Safely update the timings in the `Timeline` after performing all the necessary actions.
+pub(crate) fn _timeline_update_system(
+    q_sequences: Query<&Sequence>,
+    mut q_timelines: Query<&mut Timeline>,
+    time: Res<Time>,
+) {
+    for mut timeline in q_timelines.iter_mut() {
+        let Some(target_sequence) = timeline.target_sequence else {
+            return;
+        };
+
+        let Ok(sequence) = q_sequences.get(target_sequence) else {
+            return;
+        };
+
+        timeline.curr_time = timeline.target_time;
+
+        if timeline.is_playing {
+            timeline.target_time += time.delta_seconds() * timeline.time_scale;
+        }
+
+        timeline.target_time = f32::clamp(timeline.target_time, 0.0, sequence.duration);
+    }
 }

--- a/crates/motiongfx_vello/src/svg.rs
+++ b/crates/motiongfx_vello/src/svg.rs
@@ -124,7 +124,7 @@ pub fn spawn_tree_flatten(
         .map(|svg_path| svg_path.entity)
         .collect();
 
-    commands.entity(root_entity).push_children(&child_entities);
+    commands.entity(root_entity).push_children(child_entities);
 
     svg_tree_bundle
 }

--- a/examples/easings.rs
+++ b/examples/easings.rs
@@ -66,7 +66,7 @@ pub fn easings(
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
     // Generate cube animations
-    let mut cube_actions: Vec<ActionMetaGroup> = Vec::with_capacity(CAPACITY);
+    let mut cube_actions: Vec<Sequence> = Vec::with_capacity(CAPACITY);
 
     let easings: [ease::EaseFn; CAPACITY] = [
         ease::linear,

--- a/examples/easings.rs
+++ b/examples/easings.rs
@@ -21,7 +21,6 @@ fn main() {
 
 pub fn easings(
     mut commands: Commands,
-    mut sequence: ResMut<Sequence>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -95,7 +94,10 @@ pub fn easings(
         );
     }
 
-    sequence.play(chain(&cube_actions));
+    let sequence: Sequence = chain(&cube_actions);
+
+    let sequence_id: Entity = commands.spawn(sequence).id();
+    commands.spawn(Timeline::new(sequence_id));
 }
 
 fn setup(mut commands: Commands) {
@@ -122,23 +124,25 @@ fn setup(mut commands: Commands) {
 }
 
 fn timeline_movement_system(
-    mut timeline: ResMut<Timeline>,
+    mut q_timelines: Query<&mut Timeline>,
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    if keys.pressed(KeyCode::D) {
-        timeline.target_time += time.delta_seconds();
-    }
+    for mut timeline in q_timelines.iter_mut() {
+        if keys.pressed(KeyCode::D) {
+            timeline.target_time += time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::A) {
-        timeline.target_time -= time.delta_seconds();
-    }
+        if keys.pressed(KeyCode::A) {
+            timeline.target_time -= time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
-        timeline.time_scale = -1.0;
-        timeline.is_playing = true;
-    } else if keys.pressed(KeyCode::Space) {
-        timeline.time_scale = 1.0;
-        timeline.is_playing = true;
+        if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
+            timeline.time_scale = -1.0;
+            timeline.is_playing = true;
+        } else if keys.pressed(KeyCode::Space) {
+            timeline.time_scale = 1.0;
+            timeline.is_playing = true;
+        }
     }
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -73,7 +73,7 @@ pub fn hello_world(
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
     // Generate cube animations
-    let mut cube_actions: Vec<ActionMetaGroup> = Vec::with_capacity(CAPACITY);
+    let mut cube_actions: Vec<Sequence> = Vec::with_capacity(CAPACITY);
 
     for w in 0..WIDTH {
         for h in 0..HEIGHT {
@@ -98,7 +98,7 @@ pub fn hello_world(
         }
     }
 
-    let action_grp: ActionMetaGroup = flow(0.01, &cube_actions);
+    let action_grp: Sequence = flow(0.01, &cube_actions);
 
     sequence.play(action_grp);
 }

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -22,7 +22,6 @@ fn main() {
 
 pub fn hello_world(
     mut commands: Commands,
-    mut sequence: ResMut<Sequence>,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
@@ -98,9 +97,10 @@ pub fn hello_world(
         }
     }
 
-    let action_grp: Sequence = flow(0.01, &cube_actions);
+    let sequence: Sequence = flow(0.01, &cube_actions);
 
-    sequence.play(action_grp);
+    let sequence_id: Entity = commands.spawn(sequence).id();
+    commands.spawn(Timeline::new(sequence_id));
 }
 
 fn setup(mut commands: Commands) {
@@ -127,23 +127,25 @@ fn setup(mut commands: Commands) {
 }
 
 fn timeline_movement_system(
-    mut timeline: ResMut<Timeline>,
+    mut q_timelines: Query<&mut Timeline>,
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    if keys.pressed(KeyCode::D) {
-        timeline.target_time += time.delta_seconds();
-    }
+    for mut timeline in q_timelines.iter_mut() {
+        if keys.pressed(KeyCode::D) {
+            timeline.target_time += time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::A) {
-        timeline.target_time -= time.delta_seconds();
-    }
+        if keys.pressed(KeyCode::A) {
+            timeline.target_time -= time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
-        timeline.time_scale = -1.0;
-        timeline.is_playing = true;
-    } else if keys.pressed(KeyCode::Space) {
-        timeline.time_scale = 1.0;
-        timeline.is_playing = true;
+        if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
+            timeline.time_scale = -1.0;
+            timeline.is_playing = true;
+        } else if keys.pressed(KeyCode::Space) {
+            timeline.time_scale = 1.0;
+            timeline.is_playing = true;
+        }
     }
 }

--- a/examples/typst_basic.rs
+++ b/examples/typst_basic.rs
@@ -25,7 +25,6 @@ fn setup(mut commands: Commands) {
 
 fn typst_basic(
     mut commands: Commands,
-    mut sequence: ResMut<Sequence>,
     mut typst_compiler: ResMut<TypstCompiler>,
     mut fragment_assets: ResMut<Assets<VelloFragment>>,
 ) {
@@ -124,10 +123,11 @@ fn typst_basic(
                 ]));
             }
 
-            sequence.play(
-                all(&[all(&setup_actions), flow(0.1, &animate_actions)])
-                    .with_ease(ease::expo::ease_in_out),
-            );
+            let sequence: Sequence = all(&[all(&setup_actions), flow(0.1, &animate_actions)])
+                .with_ease(ease::expo::ease_in_out);
+
+            let sequence_id: Entity = commands.spawn(sequence).id();
+            commands.spawn(Timeline::new(sequence_id));
         }
         Err(err) => {
             println!("{:#?}", err);
@@ -136,23 +136,25 @@ fn typst_basic(
 }
 
 fn timeline_movement_system(
-    mut timeline: ResMut<Timeline>,
+    mut q_timelines: Query<&mut Timeline>,
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    if keys.pressed(KeyCode::D) {
-        timeline.target_time += time.delta_seconds();
-    }
+    for mut timeline in q_timelines.iter_mut() {
+        if keys.pressed(KeyCode::D) {
+            timeline.target_time += time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::A) {
-        timeline.target_time -= time.delta_seconds();
-    }
+        if keys.pressed(KeyCode::A) {
+            timeline.target_time -= time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
-        timeline.time_scale = -1.0;
-        timeline.is_playing = true;
-    } else if keys.pressed(KeyCode::Space) {
-        timeline.time_scale = 1.0;
-        timeline.is_playing = true;
+        if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
+            timeline.time_scale = -1.0;
+            timeline.is_playing = true;
+        } else if keys.pressed(KeyCode::Space) {
+            timeline.time_scale = 1.0;
+            timeline.is_playing = true;
+        }
     }
 }

--- a/examples/typst_basic.rs
+++ b/examples/typst_basic.rs
@@ -88,8 +88,8 @@ fn typst_basic(
             // Actions
             let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
-            let mut setup_actions: Vec<ActionMetaGroup> = Vec::with_capacity(path_len);
-            let mut animate_actions: Vec<ActionMetaGroup> = Vec::with_capacity(path_len);
+            let mut setup_actions: Vec<Sequence> = Vec::with_capacity(path_len);
+            let mut animate_actions: Vec<Sequence> = Vec::with_capacity(path_len);
 
             let transform_offset: Vec3 = Vec3::Y * 24.0;
 

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -19,11 +19,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 }
 
-fn vello_basic(
-    mut commands: Commands,
-    mut fragments: ResMut<Assets<VelloFragment>>,
-    mut sequence: ResMut<Sequence>,
-) {
+fn vello_basic(mut commands: Commands, mut fragments: ResMut<Assets<VelloFragment>>) {
     // Color palette
     let palette: ColorPalette<ColorKey> = ColorPalette::default();
 
@@ -75,7 +71,7 @@ fn vello_basic(
     // Actions
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
-    let actions: Sequence = flow(
+    let sequence: Sequence = flow(
         0.5,
         &[
             // Line animation
@@ -145,27 +141,30 @@ fn vello_basic(
     )
     .with_ease(ease::cubic::ease_in_out);
 
-    sequence.play(actions);
+    let sequence_id: Entity = commands.spawn(sequence).id();
+    commands.spawn(Timeline::new(sequence_id));
 }
 
 fn timeline_movement_system(
-    mut timeline: ResMut<Timeline>,
+    mut q_timelines: Query<&mut Timeline>,
     keys: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    if keys.pressed(KeyCode::D) {
-        timeline.target_time += time.delta_seconds();
-    }
+    for mut timeline in q_timelines.iter_mut() {
+        if keys.pressed(KeyCode::D) {
+            timeline.target_time += time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::A) {
-        timeline.target_time -= time.delta_seconds();
-    }
+        if keys.pressed(KeyCode::A) {
+            timeline.target_time -= time.delta_seconds();
+        }
 
-    if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
-        timeline.time_scale = -1.0;
-        timeline.is_playing = true;
-    } else if keys.pressed(KeyCode::Space) {
-        timeline.time_scale = 1.0;
-        timeline.is_playing = true;
+        if keys.pressed(KeyCode::Space) && keys.pressed(KeyCode::ShiftLeft) {
+            timeline.time_scale = -1.0;
+            timeline.is_playing = true;
+        } else if keys.pressed(KeyCode::Space) {
+            timeline.time_scale = 1.0;
+            timeline.is_playing = true;
+        }
     }
 }

--- a/examples/vello_basic.rs
+++ b/examples/vello_basic.rs
@@ -75,7 +75,7 @@ fn vello_basic(
     // Actions
     let mut act: ActionBuilder = ActionBuilder::new(&mut commands);
 
-    let actions: ActionMetaGroup = flow(
+    let actions: Sequence = flow(
         0.5,
         &[
             // Line animation


### PR DESCRIPTION
Closes #6 

- replace `ActionMetaGroup` with `Sequence`
- change `Sequence` and `Timeline` into components
- update examples
- allow timeline to be added as an action so that a selected portion (can be the entire timeline) of it can be played